### PR TITLE
Provide aliases for signature constructors

### DIFF
--- a/source/libraries/signet/Signet.hs
+++ b/source/libraries/signet/Signet.hs
@@ -23,7 +23,7 @@ module Signet
     Signet.Unstable.Type.PublicKey.PublicKey (..),
     Signet.Unstable.Type.Secret.Secret (..),
     Signet.Unstable.Type.SecretKey.SecretKey (..),
-    Signet.Unstable.Type.Signature.Signature (..),
+    Signet.Unstable.Type.Signature.Signature (Signet.Unstable.AsymmetricSignature, Signet.Unstable.SymmetricSignature),
     Signet.Unstable.Type.Signatures.Signatures (..),
     Signet.Unstable.parseSignatures,
     Signet.Unstable.Type.Signer.Signer (Signet.Unstable.AsymmetricSigner, Signet.Unstable.SymmetricSigner),

--- a/source/libraries/unstable/Signet/Unstable.hs
+++ b/source/libraries/unstable/Signet/Unstable.hs
@@ -182,3 +182,13 @@ pattern SymmetricSigner :: Secret.Secret -> Signer.Signer
 pattern SymmetricSigner secret = Signer.Symmetric secret
 
 {-# COMPLETE AsymmetricSigner, SymmetricSigner #-}
+
+-- | Alias for 'Signature.Asymmetric'.
+pattern AsymmetricSignature :: Signature.Signature -> Signature.Signature
+pattern AsymmetricSignature signature = signature
+
+-- | Alias for 'Signature.Symmetric'.
+pattern SymmetricSignature :: Signature.Signature -> Signature.Signature
+pattern SymmetricSignature signature = signature
+
+{-# COMPLETE AsymmetricSignature, SymmetricSignature #-}


### PR DESCRIPTION
The bare `Asymmetric` and `Symmetric` constructors for `Signature` are ambiguous. I provide aliases for signers and verifiers already. This PR adds aliases for signatures too. 