### PR TITLE
Make sub-libraries public

### DIFF
--- a/signet.cabal
+++ b/signet.cabal
@@ -98,6 +98,7 @@ library unstable
     Signet.Unstable.Type.Verifier
 
   hs-source-dirs: source/libraries/unstable
+  visibility: public
 
 library
   import: library
@@ -153,6 +154,7 @@ library test
     SignetTest
 
   hs-source-dirs: source/libraries/test
+  visibility: public
 
 test-suite signet-test-suite
   import: executable


### PR DESCRIPTION
I wrongly thought that they were public by default. 

> Default value: `private` for sublibraries. Cannot be set for the main library, which is always `public`.

https://cabal.readthedocs.io/en/3.12/cabal-package-description-file.html#pkg-field-library-visibility