### PR TITLE
Sort case insensitively

### DIFF
--- a/signet.cabal
+++ b/signet.cabal
@@ -111,9 +111,9 @@ library
     Signet.Unstable.Type.SecretKeyTest
     Signet.Unstable.Type.SecretTest
     Signet.Unstable.Type.Signature
-    Signet.Unstable.Type.SignatureTest
     Signet.Unstable.Type.Signatures
     Signet.Unstable.Type.SignaturesTest
+    Signet.Unstable.Type.SignatureTest
     Signet.Unstable.Type.Signer
     Signet.Unstable.Type.SignerTest
     Signet.Unstable.Type.SymmetricSignature


### PR DESCRIPTION
CI was failing due to <https://github.com/tfausak/cabal-gild/releases/tag/1.8.4.1>. 